### PR TITLE
Added support to set project variables.

### DIFF
--- a/Tasks/FinalBuilder/finalbuilder.ps1
+++ b/Tasks/FinalBuilder/finalbuilder.ps1
@@ -2,6 +2,7 @@ param (
     [string]$projectfile, # Path to finalbuilder project. 
     [string]$cwd, # Path to current working directory.
 	[string]$dropfolder, # Path to network location to drop built artifacts.
+	[string]$variables, # List of variables to set for the FinalBuilder project.
 	[string]$targets, # List of targets to run with in the FinalBuilder project.
 	[string]$solutionfile, # The solution file search string for the solution(s) to build.
 	[string]$platform, # The platform to build the solutions under (x86,x64,Any CPU).
@@ -25,7 +26,6 @@ function Get-FB8Arguments([string]$fbProjectFile, [string]$triggerFilename, [boo
 		$argsOut = $argsOut + " -t:`"$targets`""
 	}
     
-	# TODO Add custom variables passing from GUI	
 	# If there are any FinalBuilder variables, add them to the arguments.
 	if (-not [System.String]::IsNullOrWhiteSpace($variables)) {
 		$variables = $variables.Replace("`n", ";")
@@ -460,6 +460,7 @@ Write-Verbose "Entering script FinalBuilder.ps1"
 Write-Verbose "projectfile   = $projectfile"
 Write-Verbose "cws           = $cwd"
 Write-Verbose "dropfolder    = $dropfolder"
+Write-Verbose "variables     = $variables"
 Write-Verbose "targets       = $targets"
 Write-Verbose "solutionfile  = $solutionfile"
 Write-Verbose "platform      = $platform"

--- a/Tasks/FinalBuilder/task.json
+++ b/Tasks/FinalBuilder/task.json
@@ -23,6 +23,11 @@
             "isExpanded": true
         },
         {
+            "name": "variables",
+            "displayName": "Variables",
+            "isExpanded": true
+        },
+        {
             "name": "targets",
             "displayName": "Targets",
             "isExpanded": false
@@ -68,6 +73,15 @@
             "required": false,
             "groupName": "general",
             "helpMarkDown": "Included all changesets and files into the trigger file for FinalBuilder."
+        },
+        {
+            "name": "variables",
+            "type": "multiLine",
+            "label": "Variables",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "",
+            "groupName": "variables"
         },
         {
             "name": "targets",


### PR DESCRIPTION
We've been using the changes in this public commit for almost two years with a manually integrated task on our on premise TFS. We heavily rely on variables inside our FB8-projects which we enter via the multiline list though the configuration UI.

Because we're currently migrating to Azure DevOps we have limited options to integrate the manual task and want to adopt the feature through the official FinalBuilder-VSO task.

I hope this change is valid for public use and helps other users as well.